### PR TITLE
fix: Lookup item set value as filters.

### DIFF
--- a/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
+++ b/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
@@ -174,6 +174,8 @@ module.exports = ({ config, db }) => {
         //  Running parameters
         tableName: req.query.table_name,
         //  DSL Query
+        value: req.query.value,
+        valuesList: req.query.values_list,
         filters: req.query.filters,
         //  Custom Query
         query: req.query.query,

--- a/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
+++ b/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
@@ -160,9 +160,6 @@ module.exports = ({ config, db }) => {
    * req.query.filters - query filters
    * req.query.table_name - table name (Mandatory if is not a query)
    * req.query.query - custom query instead a table name based on SQL
-   * req.query.where_clause - where clause of search based on SQL
-   * req.query.order_by_clause - order by clause based on SQL
-   * req.query.limit - records limit
    *
    * Details:
    */
@@ -174,13 +171,9 @@ module.exports = ({ config, db }) => {
         //  Running parameters
         tableName: req.query.table_name,
         //  DSL Query
-        value: req.query.value,
         filters: req.query.filters,
         //  Custom Query
-        query: req.query.query,
-        whereClause: req.query.where_clause,
-        orderByClause: req.query.order_by_clause,
-        limit: req.query.limit
+        query: req.query.query // or direct query
       }, function (err, response) {
         if (response) {
           res.json({

--- a/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
+++ b/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
@@ -175,7 +175,6 @@ module.exports = ({ config, db }) => {
         tableName: req.query.table_name,
         //  DSL Query
         value: req.query.value,
-        valuesList: req.query.values_list,
         filters: req.query.filters,
         //  Custom Query
         query: req.query.query,


### PR DESCRIPTION
### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->


### Short description and why it's useful
Support is added to the `value` and `valuesList` in the criteria of getLookupItem service.


### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI, please provide before/after screenshots -->
Note: The numerical values are coming as string type, even if sent as numerical type from the vue client.

![proxy-api-lookup-items](https://user-images.githubusercontent.com/20288327/120048901-73232b00-bfe6-11eb-934b-8961e7904e97.png)


### Additional context
Depends on https://github.com/adempiere/gRPC-API/pull/3
Update `@adempiere/grpc-api` to 1.5.2 with the acceptance of the above-mentioned PR
