### PR TITLE
feat: Add deploy on gh-pages only changes in docs.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,2 @@
-
 # These are supported funding model platforms
-
-github: [YamelSenih]
-
-custom: 
-  - 'https://paypal.me/YamelSenih'
-  - 'https://adempiere.github.io/adempiere-vue-site/donate'
+custom: ['https://erpya.com/']

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,8 @@
+
 # These are supported funding model platforms
-custom: ['https://erpya.com/']
+
+github: [YamelSenih]
+
+custom: 
+  - 'https://paypal.me/YamelSenih'
+  - 'https://adempiere.github.io/adempiere-vue-site/donate'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   deploy:
-    name: Build and Deploy ADempiere-Proxy docs
+    name: Deploy ADempiere-Proxy docs
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,50 +1,62 @@
-# This is a basic workflow to help you get started with Actions
+# This workflow will be deployed documentation using node in GitHub Pages when a change is generated in the 'docs/' folder.
 # This file was contributed by Carlos Parada and Yamel Senih from ERP Consultores y Asociados, C.A
 
-name: ADempiere Proxy Publish
+name: ADempiere Proxy Deploy on Github Pages
 
 # Controls when the action will run. 
 on:
   push:
-    branches: [ master, develop ]
-  release:
-    types: 
-      - published
+    branches: 
+      # Push events on master and develop branchs
+      - master
+      - develop
+      - feature/**
+    # takes only the directory changes
+    paths:
+      - 'docs/**'
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  publish:
+  deploy:
+    name: Build and Deploy ADempiere-Proxy docs
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         node-version: [14.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Node configuration
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: set -e
-      - run: |
-             cd docs
-             npm i
-             npm run build
-      - run: |
-            cd docs
-            git clone https://github.com/adempiere/proxy-adempiere-api.git --branch gh-pages --single-branch gh-pages
-            cp -r .vuepress/dist/* gh-pages/
-            cd gh-pages
-            touch .nojekyll 
-            git init 
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
-            git add .
-            git commit -m "Update documentation" -a || true
-      - uses: ad-m/github-push-action@master
+
+      - name: Generate static vuepress files
+        run: |
+          cd docs
+          npm i
+          npm run build
+
+      - name: Init new repo in dist folder and commit generated files
+        run: |
+          cd docs/.vuepress/dist
+          touch .nojekyll
+          git init
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A
+          git commit -m "docs: ${{ github.event.head_commit.message }}" -a || true
+
+      - name: Force push to destination branch
+        uses: ad-m/github-push-action@v0.6.0
         with:
           branch: gh-pages
-          directory: docs/gh-pages
+          force: true
+          directory: docs/.vuepress/dist
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,6 @@ on:
       # Push events on master and develop branchs
       - master
       - develop
-      - feature/**
     # takes only the directory changes
     paths:
       - 'docs/**'

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,10 @@ features:
 footer: GNU/GPL v3 Licensed | Copyright © 2019-present ADempiere
 ---
 
+<p align="center">
+  <img width="320" src="https://upload.wikimedia.org/wikipedia/commons/b/b1/Adempiere-logo.png">
+</p>
+
 ## Getting Started
 
 ```bash
@@ -33,6 +37,8 @@ yarn install
 yarn dev
 ```
 
-## Demo
+## Live Preview
 
 [ADempiere UI Demo](https://demo-ui.erpya.com/)
+
+[ADempiere Proxy Documentation](https://adempiere.github.io/proxy-adempiere-api/)


### PR DESCRIPTION
### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
#### This change has the following improvements:

- The action name is changed from `ADempiere Proxy Publish` to `ADempiere Proxy Deploy on Github Pages`.

- Only deploy to the `gh-pages` branch when there is a change inside the `docs` directory.

- Removes the section that clones the repository unnecessarily.

- When committing to deploy the documentation place the `docs:` prefix followed by the last commit message.

- Link (https://adempiere.github.io/proxy-adempiere-api/) of the live preview is added in the readme of the documentation.


### Screenshots of visual changes before/after (if there are any)

See gh action https://github.com/EdwinBetanc0urt/proxy-adempiere-api/actions/runs/1106944207

![gh-proxy-api](https://user-images.githubusercontent.com/20288327/128584323-a8d8c60b-4db1-4aa3-b71a-571f56a6f90c.png)

