### PR TITLE
Fix error installing dependencies

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -35,7 +35,7 @@ jobs:
         run: cp -rf ./packages/default-vsf ./src/modules/
 
       - name: Install node dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install 
 
       - name: Run test
         run: yarn lint


### PR DESCRIPTION
Remove  --frozen-lockfile
```Run yarn install --frozen-lockfile
yarn install v1.22.11
[1/5] Validating package.json...
[2/5] Resolving packages...
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.```