### PR TITLE
fix: Set redis values.

### DIFF
--- a/build/Dockerfile.prod
+++ b/build/Dockerfile.prod
@@ -8,8 +8,8 @@ LABEL maintainer="EdwinBetanc0urt@outlook.com" \
 # Add system dependencies
 RUN apk --no-cache --update upgrade musl \
 	&& apk add --no-cache \
-      --virtual .build-deps \
-    curl \
+		--virtual .build-deps \
+	curl \
 		# TODO: verify git
 		git \
 		python \
@@ -24,6 +24,9 @@ ENV \
 	SERVER_PORT=8085 \
 	ES_HOST="localhost" \
 	ES_PORT=9200 \
+	REDIS_HOST="localhost" \
+	REDIS_PORT=6379 \
+	REDIS_DB=0 \
 	AD_DEFAULT_HOST="localhost" \
 	AD_DEFAULT_PORT=50059 \
 	AD_TOKEN="adempiere_token" \

--- a/build/default.json
+++ b/build/default.json
@@ -116,9 +116,9 @@
     }
   },
   "redis": {
-    "host": "localhost",
-    "port": 6379,
-    "db": 0,
+    "host": "REDIS_HOST",
+    "port": "REDIS_PORT",
+    "db": "REDIS_DB",
     "auth": false
   },
   "kue": {},
@@ -161,7 +161,7 @@
       "name": "German Store",
       "url": "/de",
       "elasticsearch": {
-        "host": "localhost:8080/api/catalog",
+        "host": "SERVER_HOST:SERVER_PORT/api/catalog",
         "index": "vue_storefront_catalog_de"
       },
       "msi": {
@@ -196,7 +196,7 @@
       "name": "Italian Store",
       "url": "/it",
       "elasticsearch": {
-        "host": "localhost:8080/api/catalog",
+        "host": "SERVER_HOST:SERVER_PORT/api/catalog",
         "index": "vue_storefront_catalog_it"
       },
       "msi": {

--- a/build/start.sh
+++ b/build/start.sh
@@ -71,11 +71,16 @@ sed -i "s|STORE_URL_IMAGES|$STORE_URL_IMAGES|g"  /var/www/proxy-adempiere-api/co
 sed -i "s|\"STORE_HTTP_BASED\"|$STORE_HTTP_BASED|g"  /var/www/proxy-adempiere-api/config/default.json
 
 
+# Set env values to redis service
+sed -i "s|REDIS_HOST|$REDIS_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
+sed -i "s|REDIS_PORT|$REDIS_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
+sed -i "s|REDIS_DB|$REDIS_DB|g"  /var/www/proxy-adempiere-api/config/default.json
+
+
 # Set env elastic search values
 sed -i "s|ES_HOST|$ES_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
 sed -i "s|ES_PORT|$ES_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
-
-# Set indices value
+# Set elastic search indices value
 sed -i "s|vue_storefront_catalog|$INDEX|g"  /var/www/proxy-adempiere-api/config/default.json
 
 


### PR DESCRIPTION
### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

#### Added configuration to point to the Redis server, fixing the error:

`
error: uncaughtException: Redis connection to localhost:6379 failed - connect ECONNREFUSED 127.0.0.1:6379 date=Sun Ago 26 2021 22:41:37 GMT+0000 (Coordinated Universal Time), pid=84, uid=0, gid=0, cwd=/var/www/proxy-adempiere-api, execPath=/usr/local/bin/node, version=v10.24.0, argv=[/var/www/proxy-adempiere-api/node_modules/.bin/ts-node, /var/www/proxy-adempiere-api/src], rss=417435648, heapTotal=371638272, heapUsed=337662376, external=250377, loadavg=[0.7734375, 0.6455078125, 0.8056640625], uptime=23557, trace=[column=14, file=net.js, function=TCPConnectWrap.afterConnect [as oncomplete], line=1107, method=afterConnect [as oncomplete], native=false], stack=[Error: Redis connection to localhost:6379 failed - connect ECONNREFUSED 127.0.0.1:6379, at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)]
`
